### PR TITLE
Redesign landing page, FlatGeobuf waterbodies, and clearer request logs

### DIFF
--- a/.changeset/landing-fgb-logging.md
+++ b/.changeset/landing-fgb-logging.md
@@ -1,0 +1,5 @@
+---
+"is-on-water": minor
+---
+
+Redesign the landing page for osbytes branding, serve waterbodies from FlatGeobuf, and clarify request log field names.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/dataset-update.yml
+++ b/.github/workflows/dataset-update.yml
@@ -1,0 +1,79 @@
+name: Dataset update
+
+on:
+  schedule:
+    # 06:17 UTC on the 1st of each month
+    - cron: '17 6 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: dataset-update
+  cancel-in-progress: false
+
+jobs:
+  check-and-pr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.12.4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check for dataset updates and rebuild
+        id: dataset
+        env:
+          # Prefer GDAL-backed FlatGeobuf (spatial index) in CI.
+          FGB_BUILDER: gdal
+        run: |
+          docker pull ghcr.io/osgeo/gdal:alpine-small-latest
+          node scripts/check-dataset-update.js
+
+      - name: Validate rebuilt dataset
+        if: steps.dataset.outputs.updated == 'true'
+        run: |
+          pnpm exec tsc --noEmit
+          pnpm test
+          pnpm build
+
+      - name: Create pull request
+        if: steps.dataset.outputs.updated == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/dataset-update
+          delete-branch: true
+          title: 'chore: update waterbodies dataset to ${{ steps.dataset.outputs.source_version }}'
+          commit-message: |
+            chore: update waterbodies FlatGeobuf to ${{ steps.dataset.outputs.source_version }}
+
+            Rebuilt from ${{ steps.dataset.outputs.source_version }} (${{ steps.dataset.outputs.feature_count }} features).
+          body: |
+            ## Summary
+            - Detected an updated `@geo-maps/earth-waterbodies-1m` package (or source content hash change)
+            - Rebuilt `data/waterbodies.fgb.gz` and `data/manifest.json`
+            - Previous version: `${{ steps.dataset.outputs.previous_version }}`
+            - New version: `${{ steps.dataset.outputs.source_version }}`
+            - Feature count: `${{ steps.dataset.outputs.feature_count }}`
+
+            ## Test plan
+            - [x] `pnpm test` (includes dataset validation fixtures)
+            - [x] `pnpm build`
+            - [ ] Spot-check critical fixtures on the demo map after merge
+
+            Automated monthly dataset refresh.
+          labels: |
+            dataset
+            automated

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 dist
 node_modules
 .tap
+data/_waterbodies.exploded.geojson
+data/_waterbodies.fc.geojson
+data/waterbodies.fgb

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Built on [Fastify](https://fastify.dev/) with optional OpenTelemetry, Swagger at
 ## Installation
 
 ```sh
-git clone https://github.com/dillonstreator/is-on-water
+git clone https://github.com/osbytes/is-on-water
 
 cd is-on-water
 
@@ -71,7 +71,15 @@ curl -X POST http://localhost:3000/api/is-on-water \
 
 ## Data
 
-Water polygons come from [`@geo-maps/earth-waterbodies-1m`](https://www.npmjs.com/package/@geo-maps/earth-waterbodies-1m) (OpenStreetMap-derived GeoJSON, package vintage 2017). The “1m” label is the upstream Douglas–Peucker simplification tolerance, **not** a measured shoreline accuracy SLA. Treat results as approximate.
+Water polygons are stored as gzip-compressed FlatGeobuf in [`data/waterbodies.fgb.gz`](./data/waterbodies.fgb.gz), built from [`@geo-maps/earth-waterbodies-1m`](https://www.npmjs.com/package/@geo-maps/earth-waterbodies-1m) (OpenStreetMap-derived; package vintage ~2017). The “1m” label is the upstream Douglas–Peucker simplification tolerance, **not** a measured shoreline accuracy SLA. Treat results as approximate.
+
+Rebuild locally:
+
+```sh
+pnpm dataset:build
+```
+
+Uses GDAL via Docker when available (`FGB_BUILDER=gdal`); otherwise falls back to the JS FlatGeobuf serializer (`FGB_BUILDER=js`). A monthly GitHub Action checks npm for source updates, rebuilds `data/`, runs the dataset validation suite, and opens a PR when something changed.
 
 © [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors. Data licensed under [ODbL](https://opendatacommons.org/licenses/odbl/).
 

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,0 +1,13 @@
+{
+  "sourcePackage": "@geo-maps/earth-waterbodies-1m",
+  "sourceVersion": "0.6.0",
+  "sourceSha256": "85f8d3f93f0f6f809f0ae90188637b86374efe2cf8300108b4f78252a2e74b69",
+  "fgbSha256": "1e98b2efdd75b2c8f3dd33724a165ecaf7306291b1303098d59694d130726299",
+  "fgbGzSha256": "6c40308211ef28634c21507f9592299b597a13a601e06462950774e585dea60f",
+  "featureCount": 3,
+  "polygonPartCount": 915482,
+  "bytes": 124260816,
+  "gzipBytes": 55148021,
+  "builder": "flatgeobuf-js",
+  "generatedAt": "2026-07-24T15:28:29.652Z"
+}

--- a/data/validation-fixtures.json
+++ b/data/validation-fixtures.json
@@ -1,0 +1,85 @@
+{
+  "description": "Ground-truth lat/lng samples used to validate waterbody datasets. critical=true fixtures must not change classification across dataset refreshes.",
+  "fixtures": [
+    {
+      "id": "mid-atlantic",
+      "lat": 20.112682,
+      "lon": -37.048647,
+      "water": true,
+      "critical": true,
+      "note": "Open ocean; used by existing API smoke test"
+    },
+    {
+      "id": "nebraska-plains",
+      "lat": 40.292097,
+      "lon": -98.613164,
+      "water": false,
+      "critical": true,
+      "note": "Continental interior land; used by existing API smoke test"
+    },
+    {
+      "id": "pacific-gyre",
+      "lat": 0.0,
+      "lon": -150.0,
+      "water": true,
+      "critical": true,
+      "note": "Central Pacific"
+    },
+    {
+      "id": "sahara",
+      "lat": 24.0,
+      "lon": 10.0,
+      "water": false,
+      "critical": true,
+      "note": "Sahara desert"
+    },
+    {
+      "id": "siberia",
+      "lat": 62.0,
+      "lon": 100.0,
+      "water": false,
+      "critical": true,
+      "note": "Interior Siberia"
+    },
+    {
+      "id": "southern-ocean",
+      "lat": -55.0,
+      "lon": 0.0,
+      "water": true,
+      "critical": true,
+      "note": "Southern Ocean"
+    },
+    {
+      "id": "lake-superior",
+      "lat": 47.7,
+      "lon": -87.5,
+      "water": true,
+      "critical": false,
+      "note": "Large inland lake; soft fixture near shoreline complexity"
+    },
+    {
+      "id": "caspian-sea",
+      "lat": 41.5,
+      "lon": 51.0,
+      "water": true,
+      "critical": false,
+      "note": "Caspian Sea interior"
+    },
+    {
+      "id": "amazon-basin-land",
+      "lat": -5.0,
+      "lon": -65.0,
+      "water": false,
+      "critical": true,
+      "note": "Amazon basin land (away from main stem)"
+    },
+    {
+      "id": "himalayas",
+      "lat": 28.0,
+      "lon": 86.9,
+      "water": false,
+      "critical": true,
+      "note": "High-elevation land near Everest"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dillonstreator/is-on-water.git"
+    "url": "git+https://github.com/osbytes/is-on-water.git"
   },
   "packageManager": "pnpm@10.12.4",
   "engines": {
@@ -14,10 +14,12 @@
   },
   "scripts": {
     "dev": "nodemon src/index.ts",
-    "build": "tsc && node -e \"require('fs').cpSync('src/public','dist/public',{recursive:true})\"",
+    "build": "tsc && node -e \"require('fs').cpSync('src/public','dist/public',{recursive:true}); require('fs').cpSync('data','dist/data',{recursive:true})\"",
     "start": "node dist/index.js",
     "test": "tap --reporter=base --allow-incomplete-coverage",
     "test:help": "tap --help",
+    "dataset:build": "node scripts/build-waterbodies-fgb.js",
+    "dataset:check": "node scripts/check-dataset-update.js",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "release": "changeset publish"
@@ -27,7 +29,10 @@
     "@babel/preset-env": "^7.29.6",
     "@babel/preset-typescript": "^7.28.5",
     "@changesets/cli": "^2.31.1",
+    "@geo-maps/earth-waterbodies-1m": "^0.6.0",
+    "@types/geojson": "^7946.0.16",
     "@types/node": "^22.15.30",
+    "@types/rbush": "^4.0.0",
     "nodemon": "^3.1.10",
     "tap": "^21.1.0",
     "ts-node": "^10.9.2",
@@ -41,7 +46,6 @@
     "@fastify/static": "^9.3.0",
     "@fastify/swagger": "^9.5.1",
     "@fastify/swagger-ui": "^5.2.2",
-    "@geo-maps/earth-waterbodies-1m": "^0.6.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.78.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
@@ -49,12 +53,14 @@
     "@opentelemetry/sdk-node": "^0.220.0",
     "@opentelemetry/sdk-trace-base": "^2.9.0",
     "@opentelemetry/semantic-conventions": "^1.43.0",
+    "@turf/boolean-point-in-polygon": "^7.3.5",
     "fastify": "^5.8.3",
     "fastify-type-provider-zod": "^4.0.2",
-    "geojson-geometries-lookup": "^0.5.0",
+    "flatgeobuf": "^4.4.0",
     "http-graceful-shutdown": "^3.1.16",
     "ioredis": "^5.6.1",
     "pino": "^9.7.0",
+    "rbush": "^4.0.1",
     "zod": "^3.25.76"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,9 +49,6 @@ importers:
       '@fastify/swagger-ui':
         specifier: ^5.2.2
         version: 5.2.6
-      '@geo-maps/earth-waterbodies-1m':
-        specifier: ^0.6.0
-        version: 0.6.0
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
@@ -73,15 +70,18 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.43.0
         version: 1.43.0
+      '@turf/boolean-point-in-polygon':
+        specifier: ^7.3.5
+        version: 7.3.5
       fastify:
         specifier: ^5.8.3
         version: 5.10.0
       fastify-type-provider-zod:
         specifier: ^4.0.2
         version: 4.0.2(fastify@5.10.0)(zod@3.25.76)
-      geojson-geometries-lookup:
-        specifier: ^0.5.0
-        version: 0.5.0
+      flatgeobuf:
+        specifier: ^4.4.0
+        version: 4.4.0
       http-graceful-shutdown:
         specifier: ^3.1.16
         version: 3.1.16
@@ -91,6 +91,9 @@ importers:
       pino:
         specifier: ^9.7.0
         version: 9.14.0
+      rbush:
+        specifier: ^4.0.1
+        version: 4.0.1
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -107,9 +110,18 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.1
         version: 2.31.1(@types/node@22.20.1)
+      '@geo-maps/earth-waterbodies-1m':
+        specifier: ^0.6.0
+        version: 0.6.0
+      '@types/geojson':
+        specifier: ^7946.0.16
+        version: 7946.0.16
       '@types/node':
         specifier: ^22.15.30
         version: 22.20.1
+      '@types/rbush':
+        specifier: ^4.0.0
+        version: 4.0.0
       nodemon:
         specifier: ^3.1.10
         version: 3.1.14
@@ -1381,6 +1393,9 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
+  '@petamoriken/float16@3.9.3':
+    resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
+
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
@@ -1414,6 +1429,9 @@ packages:
 
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
+  '@repeaterjs/repeater@3.0.6':
+    resolution: {integrity: sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==}
 
   '@sigstore/bundle@4.0.0':
     resolution: {integrity: sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==}
@@ -1610,26 +1628,14 @@ packages:
     resolution: {integrity: sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  '@turf/bbox@6.5.0':
-    resolution: {integrity: sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==}
+  '@turf/boolean-point-in-polygon@7.3.5':
+    resolution: {integrity: sha512-ba7+B0wzaS9GtERZOoXUZ6oW8IcIJHNQZf3c+tiD9ESjcsPO1Q/4qIJGTKl92nBLhhracHJxMWBM/U6hAVkaRg==}
 
-  '@turf/boolean-contains@6.5.0':
-    resolution: {integrity: sha512-4m8cJpbw+YQcKVGi8y0cHhBUnYT+QRfx6wzM4GI1IdtYH3p4oh/DOBJKrepQyiDzFDaNIjxuWXBh0ai1zVwOQQ==}
+  '@turf/helpers@7.3.5':
+    resolution: {integrity: sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==}
 
-  '@turf/boolean-point-in-polygon@6.5.0':
-    resolution: {integrity: sha512-DtSuVFB26SI+hj0SjrvXowGTUCHlgevPAIsukssW6BG5MlNSBQAo70wpICBNJL6RjukXg8d2eXaAWuD/CqL00A==}
-
-  '@turf/boolean-point-on-line@6.5.0':
-    resolution: {integrity: sha512-A1BbuQ0LceLHvq7F/P7w3QvfpmZqbmViIUPHdNLvZimFNLo4e6IQunmzbe+8aSStH9QRZm3VOflyvNeXvvpZEQ==}
-
-  '@turf/helpers@6.5.0':
-    resolution: {integrity: sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==}
-
-  '@turf/invariant@6.5.0':
-    resolution: {integrity: sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==}
-
-  '@turf/meta@6.5.0':
-    resolution: {integrity: sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==}
+  '@turf/invariant@7.3.5':
+    resolution: {integrity: sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==}
 
   '@types/aws-lambda@8.10.162':
     resolution: {integrity: sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==}
@@ -1639,6 +1645,9 @@ packages:
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -1663,6 +1672,9 @@ packages:
 
   '@types/pg@8.15.6':
     resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
+
+  '@types/rbush@4.0.0':
+    resolution: {integrity: sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ==}
 
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
@@ -1713,6 +1725,9 @@ packages:
     resolution: {integrity: sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg==}
     engines: {node: '>=16.20.0'}
     hasBin: true
+
+  '@zarrita/storage@0.2.0':
+    resolution: {integrity: sha512-855ZXqtnds7spnT8vNvD+MXa3QExP1m2GqShe8yt7uZXHnQLgJHgkpVwFjE1B0KDDRO0ki09hmk6OboTaIfPsQ==}
 
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
@@ -2007,6 +2022,9 @@ packages:
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
+  earcut@3.2.3:
+    resolution: {integrity: sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -2138,6 +2156,9 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -2153,6 +2174,12 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+
+  flatgeobuf@4.4.0:
+    resolution: {integrity: sha512-uUt1xxywP+q8K73MmyKtapF4++dMCzvoqH+ojBTsCtZBbnQEg5qy0Ujze61Rwmpmt6Ra526jpRFHtEkFun5YVw==}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -2207,13 +2234,9 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
-  geojson-geometries-lookup@0.5.0:
-    resolution: {integrity: sha512-AfadxaBda6VTwwX4USLiVofFaz0HIjubC7ZC15hGTvc8K0di3pmCNWGFotKJeURSxYPbJLFoet34X3JrIKFX4A==}
-    engines: {node: '>=10'}
-
-  geojson-geometries@2.0.0:
-    resolution: {integrity: sha512-HKljxKnbJrdkr7ijg5/nvcr1b81HP+C/rS48cJwRb3xEqiEynlGkRVkQ/msopw+EE3gf7DjEKdZyEGMck0bOpw==}
-    engines: {node: '>=10'}
+  geotiff@3.0.5:
+    resolution: {integrity: sha512-OWcL9S9+yDZ6iAlXMt32T1iwUApJM8UiD47xbm6ZP1h33d10fqkPs14EG/ttT5EnefpZSx3G15iDFC5FxUNUwA==}
+    engines: {node: '>=10.19'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -2480,6 +2503,9 @@ packages:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
 
+  lerc@3.0.0:
+    resolution: {integrity: sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==}
+
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
@@ -2671,6 +2697,12 @@ packages:
     resolution: {integrity: sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  numcodecs@0.3.2:
+    resolution: {integrity: sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==}
+
+  ol@10.9.0:
+    resolution: {integrity: sha512-svbbgVQUmEHaKpLQ8kRySojs59Brvgl2zYIrqG9eQNXGfsbi55rQasZIDpwpQzDL6OlzrUb0H4hQaiX9wDoGmA==}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -2735,6 +2767,12 @@ packages:
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
+  pako@2.2.0:
+    resolution: {integrity: sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==}
+
+  parse-headers@2.0.6:
+    resolution: {integrity: sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==}
+
   patch-console@2.0.0:
     resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2761,6 +2799,10 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pbf@4.0.1:
+    resolution: {integrity: sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==}
+    hasBin: true
 
   peek-stream@1.1.3:
     resolution: {integrity: sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==}
@@ -2804,6 +2846,9 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  point-in-polygon-hao@1.2.4:
+    resolution: {integrity: sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==}
 
   polite-json@5.0.0:
     resolution: {integrity: sha512-OLS/0XeUAcE8a2fdwemNja+udKgXNnY6yKVIXqAD2zVRx1KvY6Ato/rZ2vdzbxqYwPW0u6SCNC/bAMPNzpzxbw==}
@@ -2863,6 +2908,9 @@ packages:
     resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
+  protocol-buffers-schema@3.6.1:
+    resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
+
   pstree.remy@1.1.8:
     resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
 
@@ -2881,11 +2929,15 @@ packages:
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
-  quickselect@2.0.0:
-    resolution: {integrity: sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==}
+  quick-lru@6.1.2:
+    resolution: {integrity: sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==}
+    engines: {node: '>=12'}
 
-  rbush@3.0.1:
-    resolution: {integrity: sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==}
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
+
+  rbush@4.0.1:
+    resolution: {integrity: sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==}
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -2946,6 +2998,9 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
+  reference-spec-reader@0.2.0:
+    resolution: {integrity: sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ==}
+
   regenerate-unicode-properties@10.2.2:
     resolution: {integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==}
     engines: {node: '>=4'}
@@ -2987,6 +3042,9 @@ packages:
     resolution: {integrity: sha512-gLWKdA5tiv5j/D7ipR47u3ovbVfzFPrctTdw2Ulnpmr6PPVVSvPKGNWu09jXVNlOSLLAeD6CA13bjIelpWttSw==}
     engines: {node: 20 || >=22}
 
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
+
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
@@ -3015,6 +3073,9 @@ packages:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
     hasBin: true
+
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -3091,6 +3152,9 @@ packages:
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
+
+  slice-source@0.4.1:
+    resolution: {integrity: sha512-YiuPbxpCj4hD9Qs06hGAz/OZhQ0eDuALN0lRWJez0eD/RevzKqGdUx1IOMUnXgpr+sXZLq3g8ERwbAH0bCb8vg==}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -3280,6 +3344,9 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tuf-js@4.1.0:
     resolution: {integrity: sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -3323,6 +3390,10 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  unzipit@2.0.0:
+    resolution: {integrity: sha512-DVeVIWUZCAQPNzm5sB0hpsG1GygTTdBnzNtYYEpInkttx5evkyqRgZi6rTczoySqp8hO5jHVKzrH0f23X8FZLg==}
+    engines: {node: '>=18'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -3354,6 +3425,9 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  web-worker@1.5.0:
+    resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -3395,6 +3469,9 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xml-utils@1.10.2:
+    resolution: {integrity: sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -3444,6 +3521,9 @@ packages:
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
+  zarrita@0.7.3:
+    resolution: {integrity: sha512-wChTQ1Ox75INoQCzKAfLWAfB70JJ4KjdW8Sz5x4ZWrFB4Dw+YZdnxHTL0xSdsrB9EmKSeK7fS1Y+I2ibhfGbkw==}
+
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
@@ -3451,6 +3531,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zstddec@0.2.0:
+    resolution: {integrity: sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==}
 
 snapshots:
 
@@ -5257,6 +5340,9 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
 
+  '@petamoriken/float16@3.9.3':
+    optional: true
+
   '@pinojs/redact@0.4.0': {}
 
   '@pkgjs/parseargs@0.11.0':
@@ -5281,6 +5367,8 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.2': {}
+
+  '@repeaterjs/repeater@3.0.6': {}
 
   '@sigstore/bundle@4.0.0':
     dependencies:
@@ -5586,38 +5674,24 @@ snapshots:
       '@tufjs/canonical-json': 2.0.0
       minimatch: 10.2.5
 
-  '@turf/bbox@6.5.0':
+  '@turf/boolean-point-in-polygon@7.3.5':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/meta': 6.5.0
+      '@turf/helpers': 7.3.5
+      '@turf/invariant': 7.3.5
+      '@types/geojson': 7946.0.16
+      point-in-polygon-hao: 1.2.4
+      tslib: 2.8.1
 
-  '@turf/boolean-contains@6.5.0':
+  '@turf/helpers@7.3.5':
     dependencies:
-      '@turf/bbox': 6.5.0
-      '@turf/boolean-point-in-polygon': 6.5.0
-      '@turf/boolean-point-on-line': 6.5.0
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
-  '@turf/boolean-point-in-polygon@6.5.0':
+  '@turf/invariant@7.3.5':
     dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-
-  '@turf/boolean-point-on-line@6.5.0':
-    dependencies:
-      '@turf/helpers': 6.5.0
-      '@turf/invariant': 6.5.0
-
-  '@turf/helpers@6.5.0': {}
-
-  '@turf/invariant@6.5.0':
-    dependencies:
-      '@turf/helpers': 6.5.0
-
-  '@turf/meta@6.5.0':
-    dependencies:
-      '@turf/helpers': 6.5.0
+      '@turf/helpers': 7.3.5
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
   '@types/aws-lambda@8.10.162': {}
 
@@ -5628,6 +5702,8 @@ snapshots:
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 22.20.1
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -5658,6 +5734,8 @@ snapshots:
       '@types/node': 22.20.1
       pg-protocol: 1.15.0
       pg-types: 2.2.0
+
+  '@types/rbush@4.0.0': {}
 
   '@types/tedious@4.0.14':
     dependencies:
@@ -5693,6 +5771,12 @@ snapshots:
       '@typescript/native-preview-linux-x64': 7.0.0-dev.20260707.2
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260707.2
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260707.2
+
+  '@zarrita/storage@0.2.0':
+    dependencies:
+      reference-spec-reader: 0.2.0
+      unzipit: 2.0.0
+    optional: true
 
   abbrev@4.0.0: {}
 
@@ -5966,6 +6050,9 @@ snapshots:
       readable-stream: 3.6.2
       stream-shift: 1.0.3
 
+  earcut@3.2.3:
+    optional: true
+
   eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.5.393: {}
@@ -6086,6 +6173,9 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  fflate@0.8.3:
+    optional: true
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -6105,6 +6195,16 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  flatbuffers@25.9.23: {}
+
+  flatgeobuf@4.4.0:
+    dependencies:
+      '@repeaterjs/repeater': 3.0.6
+      flatbuffers: 25.9.23
+      slice-source: 0.4.1
+    optionalDependencies:
+      ol: 10.9.0
 
   foreground-child@3.3.1:
     dependencies:
@@ -6165,14 +6265,17 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
-  geojson-geometries-lookup@0.5.0:
+  geotiff@3.0.5:
     dependencies:
-      '@turf/bbox': 6.5.0
-      '@turf/boolean-contains': 6.5.0
-      geojson-geometries: 2.0.0
-      rbush: 3.0.1
-
-  geojson-geometries@2.0.0: {}
+      '@petamoriken/float16': 3.9.3
+      lerc: 3.0.0
+      pako: 2.2.0
+      parse-headers: 2.0.6
+      quick-lru: 6.1.2
+      web-worker: 1.5.0
+      xml-utils: 1.10.2
+      zstddec: 0.2.0
+    optional: true
 
   get-caller-file@2.0.5: {}
 
@@ -6441,6 +6544,9 @@ snapshots:
 
   jsonparse@1.3.1: {}
 
+  lerc@3.0.0:
+    optional: true
+
   light-my-request@6.6.0:
     dependencies:
       cookie: 0.7.2
@@ -6649,6 +6755,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  numcodecs@0.3.2:
+    dependencies:
+      fflate: 0.8.3
+    optional: true
+
+  ol@10.9.0:
+    dependencies:
+      '@types/rbush': 4.0.0
+      earcut: 3.2.3
+      geotiff: 3.0.5
+      pbf: 4.0.1
+      rbush: 4.0.1
+      zarrita: 0.7.3
+    optional: true
+
   on-exit-leak-free@2.1.2: {}
 
   once@1.4.0:
@@ -6719,6 +6840,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  pako@2.2.0:
+    optional: true
+
+  parse-headers@2.0.6:
+    optional: true
+
   patch-console@2.0.0: {}
 
   path-exists@4.0.0: {}
@@ -6738,6 +6865,11 @@ snapshots:
       minipass: 7.1.3
 
   path-type@4.0.0: {}
+
+  pbf@4.0.1:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+    optional: true
 
   peek-stream@1.1.3:
     dependencies:
@@ -6786,6 +6918,10 @@ snapshots:
       thread-stream: 3.2.0
 
   pirates@4.0.7: {}
+
+  point-in-polygon-hao@1.2.4:
+    dependencies:
+      robust-predicates: 3.0.3
 
   polite-json@5.0.0: {}
 
@@ -6837,6 +6973,9 @@ snapshots:
       '@types/node': 22.20.1
       long: 5.3.2
 
+  protocol-buffers-schema@3.6.1:
+    optional: true
+
   pstree.remy@1.1.8: {}
 
   pump@3.0.4:
@@ -6856,11 +6995,14 @@ snapshots:
 
   quick-format-unescaped@4.0.4: {}
 
-  quickselect@2.0.0: {}
+  quick-lru@6.1.2:
+    optional: true
 
-  rbush@3.0.1:
+  quickselect@3.0.0: {}
+
+  rbush@4.0.1:
     dependencies:
-      quickselect: 2.0.0
+      quickselect: 3.0.0
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -6933,6 +7075,9 @@ snapshots:
     dependencies:
       redis-errors: 1.2.0
 
+  reference-spec-reader@0.2.0:
+    optional: true
+
   regenerate-unicode-properties@10.2.2:
     dependencies:
       regenerate: 1.4.2
@@ -6974,6 +7119,11 @@ snapshots:
       glob: 13.0.6
       walk-up-path: 4.0.0
 
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.1
+    optional: true
+
   resolve@1.22.12:
     dependencies:
       es-errors: 1.3.0
@@ -7000,6 +7150,8 @@ snapshots:
     dependencies:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
+
+  robust-predicates@3.0.3: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -7067,6 +7219,8 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  slice-source@0.4.1: {}
 
   smart-buffer@4.2.0: {}
 
@@ -7308,6 +7462,8 @@ snapshots:
       typescript: 5.9.3
       walk-up-path: 4.0.0
 
+  tslib@2.8.1: {}
+
   tuf-js@4.1.0:
     dependencies:
       '@tufjs/models': 4.1.0
@@ -7339,6 +7495,9 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  unzipit@2.0.0:
+    optional: true
+
   update-browserslist-db@1.2.3(browserslist@4.28.6):
     dependencies:
       browserslist: 4.28.6
@@ -7362,6 +7521,9 @@ snapshots:
   walk-up-path@4.0.0: {}
 
   web-streams-polyfill@3.3.3: {}
+
+  web-worker@1.5.0:
+    optional: true
 
   which@2.0.2:
     dependencies:
@@ -7397,6 +7559,9 @@ snapshots:
 
   ws@8.21.1: {}
 
+  xml-utils@1.10.2:
+    optional: true
+
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
@@ -7431,8 +7596,17 @@ snapshots:
 
   yoga-layout@3.2.1: {}
 
+  zarrita@0.7.3:
+    dependencies:
+      '@zarrita/storage': 0.2.0
+      numcodecs: 0.3.2
+    optional: true
+
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zstddec@0.2.0:
+    optional: true

--- a/scripts/build-waterbodies-fgb.js
+++ b/scripts/build-waterbodies-fgb.js
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * Build data/waterbodies.fgb.gz (+ manifest) from @geo-maps/earth-waterbodies-1m.
+ *
+ * Stores MultiPolygon features compactly, then gzip-compresses so the committed
+ * artifact stays under GitHub's 100 MB limit. Runtime gunzips into memory and
+ * explodes rings into an RBush index.
+ */
+const { createHash } = require('node:crypto');
+const {
+    existsSync,
+    mkdirSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+    statSync,
+    createWriteStream,
+} = require('node:fs');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const { once } = require('node:events');
+const { gzipSync } = require('node:zlib');
+
+const ROOT = path.join(__dirname, '..');
+const DATA_DIR = path.join(ROOT, 'data');
+const FGB_PATH = path.join(DATA_DIR, 'waterbodies.fgb');
+const FGB_GZ_PATH = path.join(DATA_DIR, 'waterbodies.fgb.gz');
+const MANIFEST_PATH = path.join(DATA_DIR, 'manifest.json');
+const SOURCE_PACKAGE = '@geo-maps/earth-waterbodies-1m';
+const GDAL_IMAGE =
+    process.env.GDAL_IMAGE || 'ghcr.io/osgeo/gdal:alpine-small-latest';
+
+function sha256Buffer(buf) {
+    return createHash('sha256').update(buf).digest('hex');
+}
+
+function sha256File(filePath) {
+    return sha256Buffer(readFileSync(filePath));
+}
+
+function resolveSource() {
+    const pkgJson = require.resolve(`${SOURCE_PACKAGE}/package.json`);
+    const dir = path.dirname(pkgJson);
+    const version = require(`${SOURCE_PACKAGE}/package.json`).version;
+    const geoJsonPath = path.join(dir, 'map.geo.json');
+    if (!existsSync(geoJsonPath)) {
+        throw new Error(`Missing source GeoJSON at ${geoJsonPath}`);
+    }
+    return { version, geoJsonPath };
+}
+
+function toFeatureCollection(geometry) {
+    const features = [];
+    const push = (geom) => {
+        features.push({
+            type: 'Feature',
+            properties: { id: features.length },
+            geometry: geom,
+        });
+    };
+
+    const visit = (geom) => {
+        if (!geom || !geom.type) return;
+        if (geom.type === 'Polygon' || geom.type === 'MultiPolygon') {
+            push(geom);
+        } else if (geom.type === 'GeometryCollection') {
+            for (const child of geom.geometries) {
+                visit(child);
+            }
+        }
+    };
+
+    visit(geometry);
+    return { type: 'FeatureCollection', features };
+}
+
+function countPolygonParts(featureCollection) {
+    let count = 0;
+    for (const feature of featureCollection.features) {
+        const g = feature.geometry;
+        if (g.type === 'Polygon') count += 1;
+        else if (g.type === 'MultiPolygon') count += g.coordinates.length;
+    }
+    return count;
+}
+
+async function writeChunk(stream, chunk) {
+    if (!stream.write(chunk)) {
+        await once(stream, 'drain');
+    }
+}
+
+async function writeGeoJson(fc, outPath) {
+    const out = createWriteStream(outPath, { encoding: 'utf8' });
+    await writeChunk(out, JSON.stringify(fc));
+    out.end();
+    await once(out, 'finish');
+}
+
+function dockerAvailable() {
+    const result = spawnSync('docker', ['info'], {
+        stdio: 'ignore',
+        timeout: 15000,
+    });
+    return result.status === 0;
+}
+
+function buildWithGdal(tempGeoJson, outputFgb) {
+    if (existsSync(outputFgb)) {
+        rmSync(outputFgb);
+    }
+
+    if (process.env.USE_HOST_OGR === '1') {
+        const result = spawnSync(
+            'ogr2ogr',
+            [
+                '-f',
+                'FlatGeobuf',
+                '-nlt',
+                'PROMOTE_TO_MULTI',
+                '-lco',
+                'SPATIAL_INDEX=YES',
+                outputFgb,
+                tempGeoJson,
+            ],
+            { stdio: 'inherit', shell: process.platform === 'win32' }
+        );
+        if (result.status !== 0) {
+            throw new Error(`ogr2ogr failed with status ${result.status}`);
+        }
+        return 'host-ogr';
+    }
+
+    if (!dockerAvailable()) {
+        throw new Error('Docker not available');
+    }
+
+    const mount = `${ROOT}:/work`;
+    const result = spawnSync(
+        'docker',
+        [
+            'run',
+            '--rm',
+            '-v',
+            mount,
+            GDAL_IMAGE,
+            'ogr2ogr',
+            '-f',
+            'FlatGeobuf',
+            '-nlt',
+            'PROMOTE_TO_MULTI',
+            '-lco',
+            'SPATIAL_INDEX=YES',
+            `/work/data/${path.basename(outputFgb)}`,
+            `/work/data/${path.basename(tempGeoJson)}`,
+        ],
+        { stdio: 'inherit' }
+    );
+    if (result.status !== 0) {
+        throw new Error(`docker ogr2ogr failed with status ${result.status}`);
+    }
+    return 'docker-gdal';
+}
+
+async function buildWithJs(fc, outputFgb) {
+    const { geojson } = require('flatgeobuf');
+    const bytes = geojson.serialize(fc);
+    writeFileSync(outputFgb, Buffer.from(bytes));
+    return 'flatgeobuf-js';
+}
+
+async function main() {
+    mkdirSync(DATA_DIR, { recursive: true });
+
+    const { version, geoJsonPath } = resolveSource();
+    console.log(`Source: ${SOURCE_PACKAGE}@${version}`);
+    console.log(`GeoJSON: ${geoJsonPath}`);
+
+    console.log('Loading waterbody geometries…');
+    const geometry = JSON.parse(readFileSync(geoJsonPath, 'utf8'));
+    const fc = toFeatureCollection(geometry);
+    const polygonPartCount = countPolygonParts(fc);
+    console.log(
+        `Features: ${fc.features.length} (polygon parts: ${polygonPartCount})`
+    );
+
+    let builder = process.env.FGB_BUILDER || 'auto';
+    let usedBuilder;
+
+    if (builder === 'auto') {
+        try {
+            const tempGeoJson = path.join(DATA_DIR, '_waterbodies.fc.geojson');
+            console.log('Trying GDAL FlatGeobuf build…');
+            await writeGeoJson(fc, tempGeoJson);
+            usedBuilder = buildWithGdal(tempGeoJson, FGB_PATH);
+            rmSync(tempGeoJson, { force: true });
+        } catch (err) {
+            console.warn(
+                `GDAL build unavailable (${err.message}); falling back to JS serializer.`
+            );
+            usedBuilder = await buildWithJs(fc, FGB_PATH);
+        }
+    } else if (builder === 'gdal') {
+        const tempGeoJson = path.join(DATA_DIR, '_waterbodies.fc.geojson');
+        await writeGeoJson(fc, tempGeoJson);
+        usedBuilder = buildWithGdal(tempGeoJson, FGB_PATH);
+        rmSync(tempGeoJson, { force: true });
+    } else if (builder === 'js') {
+        usedBuilder = await buildWithJs(fc, FGB_PATH);
+    } else {
+        throw new Error(`Unknown FGB_BUILDER=${builder} (use auto|gdal|js)`);
+    }
+
+    const fgbBytes = readFileSync(FGB_PATH);
+    const gzBytes = gzipSync(fgbBytes, { level: 9 });
+    writeFileSync(FGB_GZ_PATH, gzBytes);
+    // Keep uncompressed out of git; regenerate locally when needed.
+    rmSync(FGB_PATH, { force: true });
+
+    const manifest = {
+        sourcePackage: SOURCE_PACKAGE,
+        sourceVersion: version,
+        sourceSha256: sha256File(geoJsonPath),
+        fgbSha256: sha256Buffer(fgbBytes),
+        fgbGzSha256: sha256Buffer(gzBytes),
+        featureCount: fc.features.length,
+        polygonPartCount,
+        bytes: fgbBytes.length,
+        gzipBytes: gzBytes.length,
+        builder: usedBuilder,
+        generatedAt: new Date().toISOString(),
+    };
+
+    writeFileSync(MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`);
+    console.log(`Builder: ${usedBuilder}`);
+    console.log(
+        `Wrote ${FGB_GZ_PATH} (${gzBytes.length} bytes gzip, ${fgbBytes.length} uncompressed)`
+    );
+    console.log(`Wrote ${MANIFEST_PATH}`);
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/scripts/check-dataset-update.js
+++ b/scripts/check-dataset-update.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Check npm for a newer @geo-maps/earth-waterbodies-1m.
+ * If updated, rebuild the FlatGeobuf dataset and exit 0 with updated=true.
+ * If unchanged, exit 0 with updated=false.
+ */
+const { spawnSync } = require('node:child_process');
+const { existsSync, readFileSync, writeFileSync, mkdirSync } = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const DATA_DIR = path.join(ROOT, 'data');
+const MANIFEST_PATH = path.join(DATA_DIR, 'manifest.json');
+const SOURCE_PACKAGE = '@geo-maps/earth-waterbodies-1m';
+const GITHUB_OUTPUT = process.env.GITHUB_OUTPUT;
+
+function setOutput(name, value) {
+    console.log(`${name}=${value}`);
+    if (!GITHUB_OUTPUT) return;
+    writeFileSync(GITHUB_OUTPUT, `${name}=${value}\n`, { flag: 'a' });
+}
+
+function loadManifest() {
+    if (!existsSync(MANIFEST_PATH)) {
+        return null;
+    }
+    return JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+}
+
+function fetchLatestVersion() {
+    const result = spawnSync(
+        'npm',
+        ['view', SOURCE_PACKAGE, 'version', '--json'],
+        { encoding: 'utf8', shell: process.platform === 'win32' }
+    );
+    if (result.status !== 0) {
+        throw new Error(
+            `npm view failed: ${result.stderr || result.stdout || result.status}`
+        );
+    }
+    return JSON.parse(result.stdout.trim());
+}
+
+function installSource(version) {
+    const result = spawnSync(
+        'pnpm',
+        ['add', '-D', `${SOURCE_PACKAGE}@${version}`],
+        { cwd: ROOT, stdio: 'inherit', shell: process.platform === 'win32' }
+    );
+    if (result.status !== 0) {
+        throw new Error(`Failed to install ${SOURCE_PACKAGE}@${version}`);
+    }
+}
+
+function rebuild() {
+    const result = spawnSync(
+        'node',
+        [path.join(__dirname, 'build-waterbodies-fgb.js')],
+        {
+            cwd: ROOT,
+            stdio: 'inherit',
+            env: {
+                ...process.env,
+                FGB_BUILDER: process.env.FGB_BUILDER || 'auto',
+            },
+        }
+    );
+    if (result.status !== 0) {
+        throw new Error('Dataset rebuild failed');
+    }
+}
+
+function main() {
+    mkdirSync(DATA_DIR, { recursive: true });
+    const manifest = loadManifest();
+    const latestVersion = fetchLatestVersion();
+    console.log(`Latest npm version: ${latestVersion}`);
+    console.log(
+        `Pinned manifest version: ${manifest ? manifest.sourceVersion : '(none)'}`
+    );
+
+    if (manifest && manifest.sourceVersion === latestVersion) {
+        console.log('Dataset is up to date.');
+        setOutput('updated', 'false');
+        setOutput('source_version', latestVersion);
+        return;
+    }
+
+    console.log('Dataset update detected; rebuilding FlatGeobuf…');
+    installSource(latestVersion);
+    rebuild();
+
+    const next = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+    setOutput('updated', 'true');
+    setOutput('source_version', next.sourceVersion);
+    setOutput('previous_version', manifest ? manifest.sourceVersion : '');
+    setOutput(
+        'feature_count',
+        String(next.polygonPartCount || next.featureCount)
+    );
+}
+
+main();

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -1,12 +1,14 @@
 import pino from 'pino';
 import { initApp } from './app';
 import { initConfig } from './config';
+import { initWaterLookup } from './is-on-water';
 
 import tap, { Test } from 'tap';
 import { Client } from 'undici';
 import { AddressInfo } from 'node:net';
 
 const initAppTest = async (t: Test) => {
+    await initWaterLookup();
     const config = {
         ...(await initConfig()),
         healthCheckEndpoint: '/some-health-check-endpoint',
@@ -103,19 +105,34 @@ tap.test('app', async (t) => {
         await response.body.dump();
     });
 
-    t.test('should serve the demo map', async (t) => {
+    t.test('should serve the landing page', async (t) => {
         const response = await client.request({
             method: 'GET',
             path: '/',
         });
 
         t.equal(response.statusCode, 200);
+        t.match(String(response.headers['cache-control']), /public/);
+        t.match(String(response.headers['cache-control']), /max-age=300/);
+        t.ok(response.headers.etag);
+        t.ok(response.headers['last-modified']);
+
         const body = await response.body.text();
         t.match(body, /Is On Water/);
-        t.match(body, /leaflet/i);
         t.match(body, /coord-form/);
+        t.match(body, /\/api\/is-on-water/);
+        t.match(body, /osbytes\.io\/badge/);
+        t.match(body, /github\.com\/osbytes\/is-on-water/);
         t.match(body, /OpenStreetMap/);
         t.match(body, /geo-maps/);
+
+        const cached = await client.request({
+            method: 'GET',
+            path: '/',
+            headers: { 'if-none-match': String(response.headers.etag) },
+        });
+        t.equal(cached.statusCode, 304);
+        await cached.body.dump();
     });
 
     t.test('swagger info version matches package.json', async (t) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,6 +20,7 @@ import fastifySwaggerUI from '@fastify/swagger-ui';
 
 import { Config } from './config';
 import { isOnWater } from './is-on-water';
+import { AppLogController } from './logging';
 
 const { name: packageName, version: packageVersion } = JSON.parse(
     readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')
@@ -60,6 +61,7 @@ export const initApp = async (config: Config, logger: pino.Logger) => {
 
     const app = Fastify({
         loggerInstance: logger,
+        logController: new AppLogController(),
         trustProxy: config.trustProxy,
         bodyLimit: 1024,
         genReqId: () => randomUUID(),
@@ -72,7 +74,7 @@ export const initApp = async (config: Config, logger: pino.Logger) => {
             info: {
                 title: packageName,
                 description:
-                    'Check whether a geographic coordinate is on water (seas, lakes, and rivers). Water polygons © OpenStreetMap contributors via geo-maps; shoreline accuracy is approximate.',
+                    'Check whether a geographic coordinate is on water (seas, lakes, and rivers). Water polygons © OpenStreetMap contributors (via geo-maps FlatGeobuf); shoreline accuracy is approximate.',
                 version: packageVersion,
             },
             servers: [],
@@ -83,12 +85,18 @@ export const initApp = async (config: Config, logger: pino.Logger) => {
     await app.register(helmet, {
         contentSecurityPolicy: {
             directives: {
-                'script-src': ["'self'", "'unsafe-inline'", 'https://unpkg.com'],
-                'style-src': ["'self'", "'unsafe-inline'", 'https://unpkg.com'],
+                'script-src': ["'self'", "'unsafe-inline'"],
+                'style-src': [
+                    "'self'",
+                    "'unsafe-inline'",
+                    'https://fonts.googleapis.com',
+                ],
+                'font-src': ["'self'", 'https://fonts.gstatic.com'],
                 'img-src': [
                     "'self'",
                     'data:',
-                    'https://tile.openstreetmap.org',
+                    'https://osbytes.io',
+                    'https://www.osbytes.io',
                     'https://railway.app',
                 ],
                 'connect-src': ["'self'"],
@@ -120,6 +128,11 @@ export const initApp = async (config: Config, logger: pino.Logger) => {
         root: path.join(__dirname, 'public'),
         wildcard: false,
         index: false,
+        // Landing HTML changes only on deploy; short TTL + ETag/Last-Modified.
+        maxAge: '5 minutes',
+        etag: true,
+        lastModified: true,
+        cacheControl: true,
     });
 
     await app.after();
@@ -150,7 +163,12 @@ export const initApp = async (config: Config, logger: pino.Logger) => {
     });
 
     app.get('/', (_req, res) => {
-        return res.sendFile('index.html');
+        return res.sendFile('index.html', {
+            maxAge: '5 minutes',
+            etag: true,
+            lastModified: true,
+            cacheControl: true,
+        });
     });
 
     app.withTypeProvider<ZodTypeProvider>().route({

--- a/src/dataset.test.ts
+++ b/src/dataset.test.ts
@@ -1,0 +1,153 @@
+import tap from 'tap';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import type RBush from 'rbush';
+import {
+    buildWaterIndex,
+    fixturesPath,
+    fgbGzPath,
+    fgbPath,
+    loadFeaturesFromFgb,
+    loadManifest,
+    manifestPath,
+    pointInWaterIndex,
+    readFgbBytes,
+    type BBoxItem,
+} from '../src/waterbodies-index';
+
+type ValidationFixture = {
+    id: string;
+    lat: number;
+    lon: number;
+    water: boolean;
+    critical: boolean;
+    note?: string;
+};
+
+type ValidationFixturesFile = {
+    description: string;
+    fixtures: ValidationFixture[];
+};
+
+const sha256 = (buf: Buffer | Uint8Array) =>
+    createHash('sha256').update(buf).digest('hex');
+
+let sharedIndex: RBush<BBoxItem> | null = null;
+let sharedFeatureCount = 0;
+
+tap.before(async () => {
+    const features = await loadFeaturesFromFgb();
+    sharedFeatureCount = features.length;
+    sharedIndex = buildWaterIndex(features);
+});
+
+tap.test('dataset artifacts exist', async (t) => {
+    t.ok(
+        existsSync(fgbGzPath) || existsSync(fgbPath),
+        `missing ${fgbGzPath} (or uncompressed ${fgbPath})`
+    );
+    t.ok(existsSync(manifestPath), `missing ${manifestPath}`);
+    t.ok(existsSync(fixturesPath), `missing ${fixturesPath}`);
+});
+
+tap.test('manifest matches waterbodies FlatGeobuf', async (t) => {
+    const manifest = loadManifest();
+    const bytes = readFgbBytes();
+    const gzSize = existsSync(fgbGzPath) ? statSync(fgbGzPath).size : null;
+
+    t.equal(manifest.sourcePackage, '@geo-maps/earth-waterbodies-1m');
+    t.type(manifest.sourceVersion, 'string');
+    t.match(manifest.sourceVersion, /^\d+\.\d+\.\d+/);
+    t.equal(manifest.fgbSha256, sha256(bytes));
+    t.equal(manifest.bytes, bytes.byteLength);
+    if (gzSize != null && manifest.gzipBytes != null) {
+        t.equal(manifest.gzipBytes, gzSize);
+        t.ok(
+            gzSize < 95 * 1024 * 1024,
+            'gzip artifact should stay under GitHub 100MB limit'
+        );
+    }
+    t.ok(manifest.featureCount >= 1, 'expected at least one waterbody feature');
+    t.ok(
+        (manifest.polygonPartCount ?? 0) > 1000 ||
+            manifest.featureCount > 1000,
+        'expected a global waterbody polygon part count'
+    );
+    t.ok(
+        bytes.byteLength > 1_000_000,
+        'FlatGeobuf should be non-trivial in size'
+    );
+});
+
+tap.test('FlatGeobuf loads and indexes', async (t) => {
+    const manifest = loadManifest();
+    t.equal(
+        sharedFeatureCount,
+        manifest.featureCount,
+        'top-level feature count should match manifest'
+    );
+
+    const expectedParts = manifest.polygonPartCount ?? sharedFeatureCount;
+    t.equal(
+        sharedIndex!.all().length,
+        expectedParts,
+        'indexed polygon parts should match manifest'
+    );
+});
+
+tap.test('validation fixtures against current dataset', async (t) => {
+    const fixturesFile = JSON.parse(
+        readFileSync(fixturesPath, 'utf8')
+    ) as ValidationFixturesFile;
+    t.ok(fixturesFile.fixtures.length >= 5, 'need a meaningful fixture suite');
+
+    const softFailures: string[] = [];
+
+    for (const fixture of fixturesFile.fixtures) {
+        const actual = pointInWaterIndex(
+            sharedIndex!,
+            fixture.lon,
+            fixture.lat
+        );
+        const msg = `${fixture.id} (${fixture.lat}, ${fixture.lon}) expected water=${fixture.water} got ${actual}${
+            fixture.note ? ` — ${fixture.note}` : ''
+        }`;
+
+        if (fixture.critical) {
+            t.equal(actual, fixture.water, msg);
+        } else if (actual !== fixture.water) {
+            softFailures.push(msg);
+        } else {
+            t.pass(msg);
+        }
+    }
+
+    if (softFailures.length) {
+        t.comment(
+            `soft fixture mismatches (non-fatal for dataset refresh):\n${softFailures.join(
+                '\n'
+            )}`
+        );
+    }
+});
+
+tap.test('dataset refresh regression helpers', async (t) => {
+    const fixturesFile = JSON.parse(
+        readFileSync(fixturesPath, 'utf8')
+    ) as ValidationFixturesFile;
+
+    const critical = fixturesFile.fixtures.filter((f) => f.critical);
+    const waterCritical = critical.filter((f) => f.water);
+    const landCritical = critical.filter((f) => !f.water);
+
+    t.ok(waterCritical.length >= 2, 'need critical open-water fixtures');
+    t.ok(landCritical.length >= 2, 'need critical inland-land fixtures');
+
+    for (const fixture of fixturesFile.fixtures) {
+        t.ok(fixture.id.length > 0);
+        t.ok(fixture.lat >= -90 && fixture.lat <= 90);
+        t.ok(fixture.lon >= -180 && fixture.lon <= 180);
+        t.type(fixture.water, 'boolean');
+        t.type(fixture.critical, 'boolean');
+    }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,15 @@ import { otlpShutdown } from './telemetry';
 import { initApp } from './app';
 import { Env, initConfig } from './config';
 import { initLogging } from './logging';
+import { initWaterLookup } from './is-on-water';
 import gracefulShutdown from 'http-graceful-shutdown';
 
 const main = async () => {
     const config = await initConfig();
     const logger = await initLogging(config);
+    logger.info('Loading waterbodies FlatGeobuf…');
+    await initWaterLookup();
+    logger.info('Waterbodies index ready');
     const app = await initApp(config, logger);
 
     await app.fastify.listen({

--- a/src/is-on-water.ts
+++ b/src/is-on-water.ts
@@ -1,9 +1,10 @@
-// geo-maps / geojson-geometries-lookup ship without TypeScript types
-// @ts-nocheck
-import GeoJsonLookup from "geojson-geometries-lookup";
-import getMapWaterbodies from "@geo-maps/earth-waterbodies-1m";
-
-const waterLookup = new GeoJsonLookup(getMapWaterbodies());
+import {
+    buildWaterIndex,
+    loadFeaturesFromFgb,
+    pointInWaterIndex,
+    type BBoxItem,
+} from './waterbodies-index';
+import type RBush from 'rbush';
 
 export type Coordinate = {
     lat: number;
@@ -16,14 +17,33 @@ export type IsOnWaterResult = {
     lon: number;
 };
 
+let waterIndex: RBush<BBoxItem> | null = null;
+let initPromise: Promise<void> | null = null;
+
+/**
+ * Load FlatGeobuf waterbodies and build the in-memory spatial index.
+ * Safe to call multiple times; initialization runs once.
+ */
+export const initWaterLookup = async (): Promise<void> => {
+    if (waterIndex) return;
+    if (!initPromise) {
+        initPromise = (async () => {
+            const features = await loadFeaturesFromFgb();
+            waterIndex = buildWaterIndex(features);
+        })();
+    }
+    await initPromise;
+};
+
 export const isOnWater = ({ lat, lon }: Coordinate): IsOnWaterResult => {
-    const water = waterLookup.hasContainers({
-        type: "Point",
-        coordinates: [lon, lat],
-    });
+    if (!waterIndex) {
+        throw new Error(
+            'Water lookup not initialized. Call await initWaterLookup() before isOnWater().'
+        );
+    }
 
     return {
-        water,
+        water: pointInWaterIndex(waterIndex, lon, lat),
         lat,
         lon,
     };

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,8 +1,98 @@
-import pino from "pino";
-import { Config } from "./config";
+import pino from 'pino';
+import {
+    LogController,
+    type FastifyReply,
+    type FastifyRequest,
+} from 'fastify';
+import { Config } from './config';
+
+/** Leaner req/res shapes for request logs (avoids verbose Fastify defaults). */
+export const requestLogSerializers = {
+    req(req: FastifyRequest) {
+        return {
+            method: req.method,
+            url: req.url,
+            host: req.host,
+            ip: req.ip,
+        };
+    },
+    res(reply: FastifyReply) {
+        return {
+            status: reply.statusCode,
+        };
+    },
+};
+
+type AppLogControllerOptions = ConstructorParameters<typeof LogController>[0];
+
+/**
+ * Request lifecycle logs with clearer field names:
+ * - reqId → id
+ * - responseTime → duration
+ * - res.statusCode → res.status (via serializers)
+ */
+export class AppLogController extends LogController {
+    constructor(options: AppLogControllerOptions = {}) {
+        super({
+            ...options,
+            requestIdLogLabel: options?.requestIdLogLabel ?? 'id',
+        });
+    }
+
+    override requestCompleted(
+        error: Error | null,
+        request: FastifyRequest,
+        reply: FastifyReply,
+        _metadata?: Record<string, unknown>
+    ): void {
+        if (this.isLogDisabled(request)) return;
+
+        if (error) {
+            reply.log.error(
+                { res: reply, err: error, duration: reply.elapsedTime },
+                'request errored'
+            );
+            return;
+        }
+
+        reply.log.info(
+            { res: reply, duration: reply.elapsedTime },
+            'request completed'
+        );
+    }
+
+    override serializerError(
+        error: Error,
+        request: FastifyRequest,
+        reply: FastifyReply,
+        metadata: { statusCode: number }
+    ): void {
+        if (this.isLogDisabled(request)) return;
+
+        reply.log.error(
+            { err: error, status: metadata.statusCode },
+            'The serializer for the given status code failed'
+        );
+    }
+
+    override serviceUnavailable(
+        logger: { info: (obj: object, msg?: string) => void },
+        _server: unknown
+    ): void {
+        logger.info(
+            { res: { status: 503 } },
+            'request aborted - refusing to accept new requests as server is closing'
+        );
+    }
+}
 
 export const initLogging = async (config: Config): Promise<pino.Logger> => {
     return pino({
         level: config.logLevel,
+        serializers: {
+            req: requestLogSerializers.req,
+            res: requestLogSerializers.res,
+            err: pino.stdSerializers.err,
+        },
     });
-}
+};

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -4,208 +4,620 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Is On Water</title>
-    <meta name="description" content="Click the map or enter coordinates to check whether a point is on water. Self-hostable HTTP API for seas, lakes, and rivers.">
+    <meta name="description" content="Check whether a geographic coordinate is on water (seas, lakes, and rivers). Self-hostable HTTP API.">
     <meta property="og:title" content="Is On Water">
-    <meta property="og:description" content="Check whether a geographic coordinate is on water via a self-hostable HTTP API.">
+    <meta property="og:description" content="Check whether a geographic coordinate is on water (seas, lakes, and rivers) via a self-hostable HTTP API.">
     <meta property="og:type" content="website">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>💧</text></svg>">
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-    integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
-    crossorigin=""/>
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-    integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
-    crossorigin=""></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        :root {
+            --bg: #ffffff;
+            --fg: #111111;
+            --muted: #6b6b6b;
+            --border: #e8e8e8;
+            --surface: #fafafa;
+            --water: #1a5f8a;
+            --land: #3d3d3d;
+        }
+
+        * { box-sizing: border-box; }
+
         html, body {
             margin: 0;
-            height: 100%;
-            font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+            padding: 0;
+            background: var(--bg);
+            color: var(--fg);
+            font-family: "IBM Plex Sans", sans-serif;
+            font-size: 16px;
+            line-height: 1.5;
+            -webkit-font-smoothing: antialiased;
         }
-        #map { height: 100%; }
-        .panel {
-            background: #fff;
-            padding: 0.75rem;
-            border-radius: 5px;
-            box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+
+        a { color: inherit; }
+
+        .mono {
+            font-family: "IBM Plex Mono", ui-monospace, monospace;
+        }
+
+        .site-header {
             display: flex;
-            flex-direction: column;
-            gap: 0.5rem;
-            max-width: 20rem;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            padding: 1rem 1.5rem;
+            border-bottom: 1px solid var(--border);
         }
-        .panel h1 {
-            margin: 0;
-            font-size: 1rem;
-            font-weight: 700;
-            line-height: 1.2;
-        }
-        .panel p {
-            margin: 0;
-            font-size: 0.75rem;
-            color: #444;
-            line-height: 1.35;
-        }
-        .coords {
-            display: grid;
-            grid-template-columns: 1fr 1fr auto;
-            gap: 0.35rem;
-            align-items: end;
-        }
-        .coords label {
-            display: flex;
-            flex-direction: column;
-            gap: 0.15rem;
-            font-size: 0.65rem;
-            color: #666;
-        }
-        .coords input {
-            width: 100%;
-            box-sizing: border-box;
-            padding: 0.35rem;
-            border: 1px solid #ccc;
-            border-radius: 3px;
-            font: inherit;
-            font-size: 0.75rem;
-        }
-        .coords button {
-            padding: 0.35rem 0.55rem;
-            border: 1px solid #222;
-            border-radius: 3px;
-            background: #222;
-            color: #fff;
-            font: inherit;
-            font-size: 0.75rem;
-            cursor: pointer;
-        }
-        .coords button:hover { background: #444; }
-        .api-link {
-            font-size: 0.7rem;
-            word-break: break-all;
-        }
-        .links {
-            display: flex;
-            flex-direction: column;
-            gap: 0.35rem;
-        }
-        .links a {
-            display: flex;
-            justify-content: center;
+
+        .brand {
+            display: inline-flex;
             align-items: center;
             gap: 0.5rem;
             text-decoration: none;
+            font-weight: 700;
+            font-size: 0.85rem;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
         }
-        .attribution {
-            font-size: 0.65rem;
-            color: #666;
-            line-height: 1.3;
+
+        .brand svg {
+            width: 1rem;
+            height: 1rem;
+            flex-shrink: 0;
         }
-        .attribution a { color: #666; }
+
+        .header-actions {
+            display: flex;
+            align-items: center;
+            gap: 0.85rem;
+        }
+
+        .header-actions a {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+            text-decoration: none;
+            color: var(--muted);
+            font-size: 0.8rem;
+            font-weight: 500;
+        }
+
+        .header-actions a:hover { color: var(--fg); }
+
+        .header-actions img {
+            display: block;
+            height: 1.35rem;
+            width: auto;
+        }
+
+        .github-icon {
+            width: 1rem;
+            height: 1rem;
+        }
+
+        main {
+            max-width: 68rem;
+            margin: 0 auto;
+            padding: 2.5rem 1.5rem 4rem;
+        }
+
+        .hero {
+            max-width: 36rem;
+            margin-bottom: 2.75rem;
+        }
+
+        .eyebrow {
+            margin: 0 0 0.75rem;
+            font-size: 0.7rem;
+            font-weight: 500;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            color: var(--muted);
+        }
+
+        .hero h1 {
+            margin: 0 0 0.85rem;
+            font-size: clamp(2rem, 4.5vw, 2.75rem);
+            font-weight: 700;
+            letter-spacing: -0.03em;
+            line-height: 1.1;
+        }
+
+        .hero p {
+            margin: 0;
+            color: var(--muted);
+            font-size: 1.05rem;
+            max-width: 32rem;
+        }
+
+        .grid {
+            display: grid;
+            grid-template-columns: 1.15fr 0.85fr;
+            gap: 2.5rem;
+            align-items: start;
+        }
+
+        @media (max-width: 860px) {
+            .grid { grid-template-columns: 1fr; gap: 2rem; }
+        }
+
+        .section-head {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .section-head h2,
+        .panel-label {
+            margin: 0;
+            font-size: 0.7rem;
+            font-weight: 600;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+            color: var(--muted);
+        }
+
+        .endpoint {
+            font-size: 0.75rem;
+            color: var(--muted);
+        }
+
+        .try {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .coords {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 0.65rem;
+        }
+
+        .coords label {
+            display: flex;
+            flex-direction: column;
+            gap: 0.3rem;
+            font-size: 0.7rem;
+            color: var(--muted);
+        }
+
+        .coords input {
+            width: 100%;
+            padding: 0.65rem 0.75rem;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            background: var(--bg);
+            font: inherit;
+            font-family: "IBM Plex Mono", ui-monospace, monospace;
+            font-size: 0.9rem;
+            color: var(--fg);
+        }
+
+        .coords input:focus {
+            outline: 2px solid #111;
+            outline-offset: 1px;
+        }
+
+        .check-btn {
+            width: 100%;
+            padding: 0.75rem 1rem;
+            border: none;
+            border-radius: 6px;
+            background: #111;
+            color: #fff;
+            font: inherit;
+            font-weight: 600;
+            font-size: 0.95rem;
+            cursor: pointer;
+        }
+
+        .check-btn:hover { background: #2a2a2a; }
+        .check-btn:disabled {
+            opacity: 0.6;
+            cursor: wait;
+        }
+
+        .response-box {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            overflow: hidden;
+            background: var(--bg);
+        }
+
+        .response-meta {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 0.75rem;
+            padding: 0.55rem 0.85rem;
+            border-bottom: 1px solid var(--border);
+            background: var(--surface);
+            font-size: 0.75rem;
+        }
+
+        .status-pill {
+            font-weight: 600;
+            text-transform: lowercase;
+        }
+
+        .status-pill.water { color: var(--water); }
+        .status-pill.land { color: var(--land); }
+        .status-pill.error { color: #a11; }
+
+        .http-status {
+            color: var(--muted);
+            font-family: "IBM Plex Mono", ui-monospace, monospace;
+        }
+
+        .response-box pre {
+            margin: 0;
+            padding: 0.85rem;
+            overflow-x: auto;
+            font-family: "IBM Plex Mono", ui-monospace, monospace;
+            font-size: 0.8rem;
+            line-height: 1.55;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+
+        .examples {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 0.5rem;
+            margin-top: 0.25rem;
+        }
+
+        .example {
+            text-align: left;
+            padding: 0.7rem 0.8rem;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: var(--bg);
+            cursor: pointer;
+            font: inherit;
+        }
+
+        .example:hover,
+        .example.active {
+            border-color: #111;
+            background: var(--surface);
+        }
+
+        .example strong {
+            display: block;
+            font-size: 0.8rem;
+            font-weight: 600;
+            margin-bottom: 0.15rem;
+        }
+
+        .example span {
+            font-family: "IBM Plex Mono", ui-monospace, monospace;
+            font-size: 0.68rem;
+            color: var(--muted);
+        }
+
+        .side {
+            display: flex;
+            flex-direction: column;
+            gap: 2rem;
+        }
+
+        .code-card {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            overflow: hidden;
+            margin-top: 0.65rem;
+        }
+
+        .code-card + .code-card { margin-top: 0.75rem; }
+
+        .code-card-head {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 0.5rem;
+            padding: 0.45rem 0.75rem;
+            border-bottom: 1px solid var(--border);
+            background: var(--surface);
+            font-size: 0.7rem;
+            color: var(--muted);
+            text-transform: lowercase;
+        }
+
+        .copy-btn {
+            border: none;
+            background: transparent;
+            color: var(--muted);
+            font: inherit;
+            font-size: 0.7rem;
+            cursor: pointer;
+            padding: 0.15rem 0.25rem;
+        }
+
+        .copy-btn:hover { color: var(--fg); }
+
+        .code-card pre {
+            margin: 0;
+            padding: 0.85rem;
+            overflow-x: auto;
+            font-family: "IBM Plex Mono", ui-monospace, monospace;
+            font-size: 0.78rem;
+            line-height: 1.55;
+            white-space: pre-wrap;
+            word-break: break-all;
+        }
+
+        .details-list {
+            list-style: none;
+            margin: 0.65rem 0 0;
+            padding: 0;
+            border-top: 1px solid var(--border);
+        }
+
+        .details-list li {
+            display: grid;
+            grid-template-columns: 7.5rem 1fr;
+            gap: 0.75rem;
+            padding: 0.7rem 0;
+            border-bottom: 1px solid var(--border);
+            font-size: 0.875rem;
+        }
+
+        .details-list dt,
+        .details-list .label {
+            color: var(--muted);
+            font-weight: 500;
+        }
+
+        .details-list a {
+            color: var(--fg);
+            text-underline-offset: 2px;
+        }
+
+        .site-footer {
+            max-width: 68rem;
+            margin: 0 auto;
+            padding: 0 1.5rem 2.5rem;
+            font-size: 0.75rem;
+            color: var(--muted);
+        }
+
+        .site-footer a { color: var(--muted); }
     </style>
 </head>
 <body>
-    <div id="map" role="application" aria-label="Map to check if a location is on water"></div>
-    <script>
-        const startLat = 0;
-        const startLon = 0;
-        const map = L.map('map').setView([startLat, startLon], 5);
-        L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            maxZoom: 12,
-            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-            noWrap: true,
-        }).addTo(map);
+    <header class="site-header">
+        <a class="brand" href="/">
+            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M12 2.5C12 2.5 5.5 10.2 5.5 14.5a6.5 6.5 0 0 0 13 0C18.5 10.2 12 2.5 12 2.5z" fill="currentColor"/>
+            </svg>
+            Is On Water
+        </a>
+        <div class="header-actions">
+            <a href="http://osbytes.io/badge" target="_blank" rel="noopener noreferrer" title="osbytes">
+                <img src="https://www.osbytes.io/badge.svg" alt="osbytes" height="22" />
+            </a>
+            <a href="https://github.com/osbytes/is-on-water" target="_blank" rel="noopener noreferrer">
+                <svg class="github-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 98 96" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="currentColor"/></svg>
+                GitHub
+            </a>
+        </div>
+    </header>
 
-        const panel = L.control({ position: 'topright' });
-        panel.onAdd = function () {
-            const div = L.DomUtil.create('div', 'info');
-            div.innerHTML = `
-                <div class="panel">
-                    <h1>Is On Water</h1>
-                    <p>Click the map or enter coordinates to check if a point is on water. Self-hostable HTTP API.</p>
-                    <form class="coords" id="coord-form">
-                        <label>lat
-                            <input id="lat-input" name="lat" type="number" step="any" min="-90" max="90" value="${startLat}" required />
-                        </label>
-                        <label>lon
-                            <input id="lon-input" name="lon" type="number" step="any" min="-180" max="180" value="${startLon}" required />
-                        </label>
-                        <button type="submit">Check</button>
-                    </form>
-                    <a class="api-link" id="api-link" href="/api/is-on-water?lat=${startLat}&lon=${startLon}" target="_blank" rel="noopener noreferrer"><strong>GET</strong> /api/is-on-water?lat=${startLat}&lon=${startLon}</a>
-                    <div class="links">
-                        <a href="/documentation" target="_blank" rel="noopener noreferrer" style="font-size:0.75rem;">API docs</a>
-                        <a style="line-height: 1;" href="https://railway.app/template/MfUYQX?referralCode=ToZEjF" target="_blank" rel="noopener noreferrer"><img style="width: 100%;" alt="Deploy on Railway" src="https://railway.app/button.svg" /></a>
-                        <a href="https://github.com/dillonstreator/is-on-water" target="_blank" rel="noopener noreferrer">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 98 96" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="#24292f"/></svg>
-                            <span style="color: gray; font-size: 0.75rem;">dillonstreator/is-on-water</span>
-                        </a>
+    <main>
+        <section class="hero">
+            <p class="eyebrow">Open source · MIT</p>
+            <h1>Is this point on water?</h1>
+            <p>Pass a latitude and longitude, get back whether it falls on water or land – seas, lakes, and rivers, worldwide. Approximate; not survey-grade.</p>
+        </section>
+
+        <div class="grid">
+            <section class="try" aria-labelledby="try-heading">
+                <div class="section-head">
+                    <h2 id="try-heading">Try it</h2>
+                    <span class="endpoint mono">GET /api/is-on-water?lat=&amp;lon=</span>
+                </div>
+
+                <form class="coords" id="coord-form">
+                    <label>lat
+                        <input id="lat-input" name="lat" type="number" step="any" min="-90" max="90" value="46.82" required />
+                    </label>
+                    <label>lon
+                        <input id="lon-input" name="lon" type="number" step="any" min="-180" max="180" value="8.22" required />
+                    </label>
+                </form>
+
+                <button class="check-btn" id="check-btn" type="submit" form="coord-form">Check</button>
+
+                <div class="response-box" aria-live="polite">
+                    <div class="response-meta">
+                        <span class="panel-label">response</span>
+                        <span>
+                            <span class="status-pill" id="status-pill">—</span>
+                            <span class="http-status" id="http-status"></span>
+                        </span>
                     </div>
-                    <p class="attribution">Water data © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">OpenStreetMap</a> contributors via <a href="https://github.com/simonepri/geo-maps" target="_blank" rel="noopener noreferrer">geo-maps</a>. Approximate; not survey-grade.</p>
-                </div>`;
-            L.DomEvent.disableClickPropagation(div);
-            L.DomEvent.disableScrollPropagation(div);
-            return div;
-        };
-        panel.addTo(map);
+                    <pre id="response-body">{}</pre>
+                </div>
+
+                <div class="examples" id="examples" role="group" aria-label="Example locations"></div>
+            </section>
+
+            <aside class="side">
+                <section aria-labelledby="usage-heading">
+                    <h2 class="panel-label" id="usage-heading">Usage</h2>
+                    <div class="code-card">
+                        <div class="code-card-head">
+                            <span>curl</span>
+                            <button type="button" class="copy-btn" id="copy-curl">Copy</button>
+                        </div>
+                        <pre id="curl-example"></pre>
+                    </div>
+                    <div class="code-card">
+                        <div class="code-card-head">
+                            <span>response</span>
+                        </div>
+                        <pre id="curl-response"></pre>
+                    </div>
+                </section>
+
+                <section aria-labelledby="details-heading">
+                    <h2 class="panel-label" id="details-heading">Details</h2>
+                    <ul class="details-list">
+                        <li>
+                            <span class="label">Endpoints</span>
+                            <span>GET single · POST batch</span>
+                        </li>
+                        <li>
+                            <span class="label">Data source</span>
+                            <span>OpenStreetMap waterbodies via <a href="https://github.com/simonepri/geo-maps" target="_blank" rel="noopener noreferrer">geo-maps</a> (~2017)</span>
+                        </li>
+                        <li>
+                            <span class="label">Accuracy</span>
+                            <span>Approximate shoreline; not survey-grade</span>
+                        </li>
+                        <li>
+                            <span class="label">Auth</span>
+                            <span>No API key required</span>
+                        </li>
+                        <li>
+                            <span class="label">Docs</span>
+                            <span><a href="/documentation">/documentation</a></span>
+                        </li>
+                        <li>
+                            <span class="label">License</span>
+                            <span>MIT (map data ODbL)</span>
+                        </li>
+                        <li>
+                            <span class="label">Deploy</span>
+                            <span><a href="https://railway.com/deploy/MfUYQX?referralCode=ToZEjF&amp;utm_medium=integration&amp;utm_source=template&amp;utm_campaign=generic" target="_blank" rel="noopener noreferrer">Railway template</a></span>
+                        </li>
+                    </ul>
+                </section>
+            </aside>
+        </div>
+    </main>
+
+    <footer class="site-footer">
+        Water data © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">OpenStreetMap</a> contributors via <a href="https://github.com/simonepri/geo-maps" target="_blank" rel="noopener noreferrer">geo-maps</a> (ODbL). Approximate; not survey-grade.
+    </footer>
+
+    <script>
+        const EXAMPLES = [
+            { name: 'Atlantic Ocean', lat: 20.112682, lon: -37.048647, water: true },
+            { name: 'Nebraska', lat: 40.292097, lon: -98.613164, water: false },
+            { name: 'Mediterranean Sea', lat: 35.2, lon: 18.5, water: true },
+            { name: 'Swiss Alps', lat: 46.82, lon: 8.22, water: false },
+        ];
 
         const latInput = document.getElementById('lat-input');
         const lonInput = document.getElementById('lon-input');
-        const apiLink = document.getElementById('api-link');
         const coordForm = document.getElementById('coord-form');
+        const checkBtn = document.getElementById('check-btn');
+        const statusPill = document.getElementById('status-pill');
+        const httpStatus = document.getElementById('http-status');
+        const responseBody = document.getElementById('response-body');
+        const examplesEl = document.getElementById('examples');
+        const curlExample = document.getElementById('curl-example');
+        const curlResponse = document.getElementById('curl-response');
+        const copyCurl = document.getElementById('copy-curl');
 
-        const popup = L.popup();
         let ab = new AbortController();
+        let activeExample = 'Swiss Alps';
 
-        const formatCoord = (n) => {
-            const rounded = Math.round(n * 1e6) / 1e6;
-            return String(rounded);
-        };
+        const formatCoord = (n) => String(n);
 
-        const updateApiLink = (lat, lon) => {
-            const href = `/api/is-on-water?lat=${lat}&lon=${lon}`;
-            apiLink.href = href;
-            apiLink.innerHTML = `<strong>GET</strong> ${href}`;
-        };
+        const apiPath = (lat, lon) =>
+            `/api/is-on-water?lat=${encodeURIComponent(lat)}&lon=${encodeURIComponent(lon)}`;
 
-        const createPopupContent = ({ water, lat, lon, error }) => {
-            if (error) {
-                return `<p style="margin: 0;">${error}</p>`;
-            }
-            return `<p style="margin: 0;">lat: ${lat}</p><p style="margin: 0;">lon: ${lon}</p><p style="margin: 0;">water: ${water === undefined ? "Loading…" : water}</p>`;
-        };
+        const apiUrl = (lat, lon) => `${window.location.origin}${apiPath(lat, lon)}`;
 
-        function lookup(lat, lon) {
-            ab?.abort();
-            ab = new AbortController();
-            latInput.value = formatCoord(lat);
-            lonInput.value = formatCoord(lon);
-            updateApiLink(lat, lon);
-
-            popup
-                .setLatLng([lat, lon])
-                .setContent(createPopupContent({ lat, lon }))
-                .openOn(map);
-
-            fetch(`/api/is-on-water?lat=${lat}&lon=${lon}`, { signal: ab.signal })
-                .then(async (res) => {
-                    if (res.status !== 200) {
-                        let detail = `Request failed (${res.status})`;
-                        try {
-                            const errBody = await res.json();
-                            if (errBody?.msg) detail = errBody.msg;
-                        } catch (_) {}
-                        throw new Error(detail);
-                    }
-                    return res.json();
-                })
-                .then((res) => { popup.setContent(createPopupContent(res)); })
-                .catch((e) => {
-                    if (e.name === 'AbortError' || e.message === 'The user aborted a request.') return;
-                    popup.setContent(createPopupContent({ lat, lon, error: e.message }));
-                });
+        function updateUsageExample() {
+            const sample = EXAMPLES[0];
+            curlExample.textContent = `curl "${apiUrl(sample.lat, sample.lon)}"`;
+            curlResponse.textContent = JSON.stringify(
+                { water: sample.water, lat: sample.lat, lon: sample.lon },
+                null,
+                2
+            );
         }
 
-        function onMapClick(e) {
-            const { lat, lng: lon } = e.latlng;
-            lookup(lat, lon);
+        function setActiveExample(name) {
+            activeExample = name;
+            examplesEl.querySelectorAll('.example').forEach((btn) => {
+                btn.classList.toggle('active', btn.dataset.name === name);
+            });
+        }
+
+        function renderExamples() {
+            examplesEl.innerHTML = EXAMPLES.map(
+                (ex) => `
+                <button type="button" class="example${ex.name === activeExample ? ' active' : ''}" data-name="${ex.name}" data-lat="${ex.lat}" data-lon="${ex.lon}">
+                    <strong>${ex.name}</strong>
+                    <span>${ex.lat}, ${ex.lon}</span>
+                </button>`
+            ).join('');
+        }
+
+        function showResult({ water, lat, lon, status, error }) {
+            if (error) {
+                statusPill.textContent = 'error';
+                statusPill.className = 'status-pill error';
+                httpStatus.textContent = status ? ` ${status}` : '';
+                responseBody.textContent = JSON.stringify({ error }, null, 2);
+                return;
+            }
+
+            const label = water ? 'water' : 'land';
+            statusPill.textContent = label;
+            statusPill.className = `status-pill ${label}`;
+            httpStatus.textContent = status ? ` ${status}` : ' 200 OK';
+            // Show the API payload as returned (boolean water flag only).
+            responseBody.textContent = JSON.stringify({ water, lat, lon }, null, 2);
+        }
+
+        async function lookup(lat, lon, exampleName) {
+            ab.abort();
+            ab = new AbortController();
+
+            latInput.value = formatCoord(lat);
+            lonInput.value = formatCoord(lon);
+            if (exampleName) setActiveExample(exampleName);
+            else setActiveExample('');
+
+            checkBtn.disabled = true;
+            statusPill.textContent = '…';
+            statusPill.className = 'status-pill';
+            httpStatus.textContent = '';
+            responseBody.textContent = 'Loading…';
+
+            try {
+                const res = await fetch(apiPath(lat, lon), { signal: ab.signal });
+                const statusText = `${res.status} ${res.statusText || 'OK'}`.trim();
+
+                if (!res.ok) {
+                    let detail = `Request failed (${res.status})`;
+                    try {
+                        const errBody = await res.json();
+                        if (errBody?.msg) detail = errBody.msg;
+                    } catch (_) {}
+                    showResult({ status: statusText, error: detail });
+                    return;
+                }
+
+                const data = await res.json();
+                showResult({ ...data, status: statusText });
+            } catch (e) {
+                if (e.name === 'AbortError') return;
+                showResult({ error: e.message || 'Request failed' });
+            } finally {
+                checkBtn.disabled = false;
+            }
         }
 
         coordForm.addEventListener('submit', (e) => {
@@ -213,12 +625,29 @@
             const lat = Number(latInput.value);
             const lon = Number(lonInput.value);
             if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
-            map.setView([lat, lon]);
             lookup(lat, lon);
         });
 
-        lookup(startLat, startLon);
-        map.on('click', onMapClick);
+        examplesEl.addEventListener('click', (e) => {
+            const btn = e.target.closest('.example');
+            if (!btn) return;
+            lookup(Number(btn.dataset.lat), Number(btn.dataset.lon), btn.dataset.name);
+        });
+
+        copyCurl.addEventListener('click', async () => {
+            try {
+                await navigator.clipboard.writeText(curlExample.textContent);
+                copyCurl.textContent = 'Copied';
+                setTimeout(() => { copyCurl.textContent = 'Copy'; }, 1200);
+            } catch (_) {
+                copyCurl.textContent = 'Failed';
+                setTimeout(() => { copyCurl.textContent = 'Copy'; }, 1200);
+            }
+        });
+
+        renderExamples();
+        updateUsageExample();
+        lookup(46.82, 8.22, 'Swiss Alps');
     </script>
 </body>
 </html>

--- a/src/waterbodies-index.ts
+++ b/src/waterbodies-index.ts
@@ -1,0 +1,181 @@
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { gunzipSync } from 'node:zlib';
+import RBush from 'rbush';
+import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
+import type { Feature, Point, Polygon, MultiPolygon } from 'geojson';
+
+export type BBoxItem = {
+    minX: number;
+    minY: number;
+    maxX: number;
+    maxY: number;
+    feature: Feature<Polygon>;
+};
+
+export type DatasetManifest = {
+    sourcePackage: string;
+    sourceVersion: string;
+    sourceSha256: string;
+    fgbSha256: string;
+    fgbGzSha256?: string;
+    featureCount: number;
+    polygonPartCount?: number;
+    bytes: number;
+    gzipBytes?: number;
+    builder?: string;
+    generatedAt: string;
+};
+
+export const dataDir = (() => {
+    const candidates = [
+        path.join(__dirname, '..', 'data'),
+        path.join(__dirname, 'data'),
+        path.join(process.cwd(), 'data'),
+    ];
+    for (const candidate of candidates) {
+        if (
+            existsSync(path.join(candidate, 'waterbodies.fgb.gz')) ||
+            existsSync(path.join(candidate, 'waterbodies.fgb'))
+        ) {
+            return candidate;
+        }
+    }
+    return candidates[0];
+})();
+export const fgbPath = path.join(dataDir, 'waterbodies.fgb');
+export const fgbGzPath = path.join(dataDir, 'waterbodies.fgb.gz');
+export const manifestPath = path.join(dataDir, 'manifest.json');
+export const fixturesPath = path.join(dataDir, 'validation-fixtures.json');
+
+function polygonBBox(
+    coordinates: Polygon['coordinates']
+): [number, number, number, number] {
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const ring of coordinates) {
+        for (const position of ring) {
+            const x = position[0];
+            const y = position[1];
+            if (x < minX) minX = x;
+            if (y < minY) minY = y;
+            if (x > maxX) maxX = x;
+            if (y > maxY) maxY = y;
+        }
+    }
+    return [minX, minY, maxX, maxY];
+}
+
+/**
+ * Explode MultiPolygon features into per-polygon RBush items so ocean-scale
+ * MultiPolygon bboxes do not defeat spatial filtering.
+ */
+export function featuresToIndexItems(
+    features: Feature<Polygon | MultiPolygon>[]
+): BBoxItem[] {
+    const items: BBoxItem[] = [];
+    for (const feature of features) {
+        const geometry = feature.geometry;
+        if (geometry.type === 'Polygon') {
+            const [minX, minY, maxX, maxY] = polygonBBox(geometry.coordinates);
+            items.push({
+                minX,
+                minY,
+                maxX,
+                maxY,
+                feature: {
+                    type: 'Feature',
+                    properties: feature.properties ?? {},
+                    geometry,
+                },
+            });
+        } else if (geometry.type === 'MultiPolygon') {
+            for (const coordinates of geometry.coordinates) {
+                const [minX, minY, maxX, maxY] = polygonBBox(coordinates);
+                items.push({
+                    minX,
+                    minY,
+                    maxX,
+                    maxY,
+                    feature: {
+                        type: 'Feature',
+                        properties: feature.properties ?? {},
+                        geometry: { type: 'Polygon', coordinates },
+                    },
+                });
+            }
+        }
+    }
+    return items;
+}
+
+export function loadManifest(filePath = manifestPath): DatasetManifest {
+    return JSON.parse(readFileSync(filePath, 'utf8')) as DatasetManifest;
+}
+
+export function readFgbBytes(
+    preferredGzPath = fgbGzPath,
+    preferredFgbPath = fgbPath
+): Uint8Array {
+    if (existsSync(preferredGzPath)) {
+        return new Uint8Array(gunzipSync(readFileSync(preferredGzPath)));
+    }
+    if (existsSync(preferredFgbPath)) {
+        return new Uint8Array(readFileSync(preferredFgbPath));
+    }
+    throw new Error(
+        `Missing waterbodies dataset at ${preferredGzPath} or ${preferredFgbPath}`
+    );
+}
+
+export async function loadFeaturesFromFgb(
+    filePathGz = fgbGzPath,
+    filePathFgb = fgbPath
+): Promise<Feature<Polygon | MultiPolygon>[]> {
+    const { geojson } = await import('flatgeobuf');
+    const bytes = readFgbBytes(filePathGz, filePathFgb);
+    const features: Feature<Polygon | MultiPolygon>[] = [];
+    for await (const feature of geojson.deserialize(bytes)) {
+        const geometry = feature.geometry;
+        if (
+            geometry &&
+            (geometry.type === 'Polygon' || geometry.type === 'MultiPolygon')
+        ) {
+            features.push(feature as Feature<Polygon | MultiPolygon>);
+        }
+    }
+    return features;
+}
+
+export function buildWaterIndex(
+    features: Feature<Polygon | MultiPolygon>[]
+): RBush<BBoxItem> {
+    const tree = new RBush<BBoxItem>();
+    tree.load(featuresToIndexItems(features));
+    return tree;
+}
+
+export function pointInWaterIndex(
+    tree: RBush<BBoxItem>,
+    lon: number,
+    lat: number
+): boolean {
+    const candidates = tree.search({
+        minX: lon,
+        minY: lat,
+        maxX: lon,
+        maxY: lat,
+    });
+    const point: Point = {
+        type: 'Point',
+        coordinates: [lon, lat],
+    };
+    for (const candidate of candidates) {
+        if (booleanPointInPolygon(point, candidate.feature)) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -102,5 +102,7 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- Replace the Leaflet demo with an osbytes-branded landing page (Try it / Usage / Details), GitHub + badge links, relative API URLs, and short HTML cache headers
- Serve waterbodies from compressed FlatGeobuf with build/check scripts, dataset validation tests, and a monthly update workflow
- Clarify request log field names (`reqId` → `id`, `responseTime` → `duration`, `statusCode` → `status`) and point repo links at `osbytes/is-on-water`

## Test plan
- [ ] `pnpm test` (app + dataset suites)
- [ ] `pnpm build && pnpm start`, open `/` and run Try it + example chips
- [ ] Confirm curl example uses the current origin and response matches API JSON
- [ ] Confirm response headers on `/` include `Cache-Control: public, max-age=300` and ETag 304 works
- [ ] Spot-check logs for `id`, `duration`, and `res.status`