### PR TITLE
fix: run corepack as root in Docker prod stage and add docker build CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,12 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+  docker-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t is-on-water:ci .

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN pnpm build
 FROM node:22-slim
 
 ENV NODE_ENV=production
-USER node
 
 WORKDIR /usr/src/app
 
@@ -24,6 +23,10 @@ COPY package.json pnpm-lock.yaml ./
 RUN corepack enable && pnpm install --prod --frozen-lockfile
 
 COPY --from=builder /usr/src/app/dist ./dist
+
+RUN chown -R node:node /usr/src/app
+
+USER node
 
 ENV PORT=3000
 EXPOSE $PORT


### PR DESCRIPTION
The production stage set USER node before running corepack enable, which failed to symlink pnpm into /usr/local/bin with EACCES, breaking the Railway deploy. Enable corepack and install deps as root, chown the app dir, then drop to the node user for runtime.

Also add a docker-build job to CI so image build breakages are caught before deploy.